### PR TITLE
feat: status report if MAKEFLAGS commented out

### DIFF
--- a/aur-boost.sh
+++ b/aur-boost.sh
@@ -115,7 +115,13 @@ statusFn() {
   # get current values of parameters supported by this script
   local file="/etc/makepkg.conf"
   echo -e "Current value in \"${file}\": \"`grep "^CFLAGS" ${file}`\""
-  echo -e "Current value in \"${file}\": \"`grep "^MAKEFLAGS" ${file}`\""
+  if grep -q "^MAKEFLAGS" ${file}; then
+    echo -e "Current value in \"${file}\": \"`grep "^MAKEFLAGS" ${file}`\""
+  elif grep -q "^#MAKEFLAGS" ${file}; then
+    echo -e "MAKEFLAGS is commented out in \"${file}\": \"`grep "^#MAKEFLAGS" ${file}`\""
+  else
+    echo -e "MAKEFLAGS is not set in \"${file}\"."
+  fi
   echo -e "Current value in \"${file}\": \"`grep "^BUILDDIR" ${file}`\""
   echo -e "Current value in \"${file}\": \"`grep "^COMPRESSZST" ${file}`\""
   unset file


### PR DESCRIPTION
statusFn() reports if MAKEFLAGS is commented out in /etcmakepkg.conf
See https://github.com/emilwojcik93/aur-boost/issues/1#issue-2164589164

Example:
```
Current value in "/etc/makepkg.conf": "CFLAGS="-march=native -O2 -pipe -fno-plt -fexceptions \"
MAKEFLAGS is commented out in "/etc/makepkg.conf": "#MAKEFLAGS="-j$(nproc)""
Current value in "/etc/makepkg.conf": "BUILDDIR=/tmp/makepkg"
Current value in "/etc/makepkg.conf": "COMPRESSZST=(zstd -c -T0 --ultra -20 -)"
Current value in "/usr/bin/makepkg":  "SKIPCHECKSUMS=0"
Current value in "/usr/bin/makepkg":  "SKIPPGPCHECK=0"
```

